### PR TITLE
Regex stringify proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ const stringify = fastJson({
     age: {
       description: 'Age in years',
       type: 'integer'
+    },
+    reg: {
+      type: 'string'
     }
   }
 })
@@ -41,7 +44,8 @@ const stringify = fastJson({
 console.log(stringify({
   firstName: 'Matteo',
   lastName: 'Collina',
-  age: 32
+  age: 32,
+  reg: /"([^"]|\\")*"/
 }))
 ```
 
@@ -61,8 +65,15 @@ Supported types:
  * `'boolean'`
  * `'null'`
 
-And nested ones, too.
-`Date` instances are serialized with `toISOString()`.
+And nested ones, too.  
+
+*Specific use cases:*
+
+| Instance   | Serialized as                               |
+| -----------|---------------------------------------------|
+| `Date`     | `string` <small>via `toISOString()`</small> |
+| `RegExp`   | `string`                                    |
+
 
 ## Acknowledgements
 

--- a/example.js
+++ b/example.js
@@ -17,6 +17,9 @@ const stringify = fastJson({
     },
     now: {
       type: 'string'
+    },
+    reg: {
+      type: 'string'
     }
   }
 })
@@ -25,5 +28,6 @@ console.log(stringify({
   firstName: 'Matteo',
   lastName: 'Collina',
   age: 32,
-  now: new Date()
+  now: new Date(),
+  reg: /"([^"]|\\")*"/
 }))

--- a/index.js
+++ b/index.js
@@ -37,9 +37,6 @@ function build (schema) {
       main = '$main'
       code = buildArray(schema, code, main)
       break
-    case 'RegExp':
-      main = $asRegExp.name
-      break
     default:
       throw new Error(`${schema.type} unsupported`)
   }
@@ -72,6 +69,8 @@ function $asBoolean (bool) {
 function $asString (str) {
   if (str instanceof Date) {
     return '"' + str.toISOString() + '"'
+  } else if (str instanceof RegExp) {
+    return $asRegExp(str)
   } else if (typeof str !== 'string') {
     str = str.toString()
   }
@@ -120,7 +119,7 @@ function $asStringSmall (str) {
 }
 
 function $asRegExp (reg) {
-  reg = reg instanceof RegExp ? reg.source : reg
+  reg = reg.source
 
   for (var i = 0, len = reg.length; i < len; i++) {
     if (reg[i] === '\\' || reg[i] === '"') {
@@ -238,11 +237,6 @@ function nested (laterCode, name, key, schema) {
       laterCode = buildArray(schema, laterCode, funcName)
       code += `
         json += ${funcName}(obj${key})
-      `
-      break
-    case 'RegExp':
-      code += `
-        json += $asRegExp(obj${key})
       `
       break
     default:

--- a/test.js
+++ b/test.js
@@ -222,3 +222,38 @@ buildTest({
 }, {
   readonly: true
 })
+
+test('object with RexExp', (t) => {
+  t.plan(3)
+
+  const schema = {
+    title: 'object with RegExp',
+    type: 'object',
+    properties: {
+      reg: {
+        type: 'RegExp'
+      },
+      streg: {
+        type: 'RegExp'
+      }
+    }
+  }
+
+  const obj = {
+    reg: /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+    streg: '^(([^<>()\\[\\]\\\\.,;:\\s@"]+(\\.[^<>()\\[\\]\\\\.,;:\\s@"]+)*)|(".+"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}])|(([a-zA-Z\\-0-9]+\\.)+[a-zA-Z]{2,}))$'
+  }
+
+  const stringify = build(schema)
+  const output = stringify(obj)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal(obj.reg.source, new RegExp(JSON.parse(output).reg).source)
+  t.equal(obj.streg, JSON.parse(output).streg)
+})

--- a/test.js
+++ b/test.js
@@ -231,20 +231,17 @@ test('object with RexExp', (t) => {
     type: 'object',
     properties: {
       reg: {
-        type: 'RegExp'
-      },
-      streg: {
-        type: 'RegExp'
+        type: 'string'
       }
     }
   }
 
   const obj = {
-    reg: /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
-    streg: '^(([^<>()\\[\\]\\\\.,;:\\s@"]+(\\.[^<>()\\[\\]\\\\.,;:\\s@"]+)*)|(".+"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}])|(([a-zA-Z\\-0-9]+\\.)+[a-zA-Z]{2,}))$'
+    reg: /"([^"]|\\")*"/
   }
 
   const stringify = build(schema)
+  const validate = validator(schema)
   const output = stringify(obj)
 
   try {
@@ -255,5 +252,5 @@ test('object with RexExp', (t) => {
   }
 
   t.equal(obj.reg.source, new RegExp(JSON.parse(output).reg).source)
-  t.equal(obj.streg, JSON.parse(output).streg)
+  t.ok(validate(JSON.parse(output)), 'valid schema')
 })


### PR DESCRIPTION
JSON by default does not support RegExp objects or strings, I propose to add `RegExp` type to the schema types.
```js
reg: {
  type: 'RegExp'
}
```
In this way *fast-json-stringify* will transform regex object in escaped strings and not in `'{}'` as *JSON.stringify* does.

Example:
```js
// Before
/"([^"]|\\")*"/
// After
'"\\"([^\\"]|\\\\\\\\\\")*\\""'

// Then
/"([^"]|\\")*"/.source === new RegExp(JSON.parse('"\\"([^\\"]|\\\\\\\\\\")*\\""')).source // true
```

What do you think?