### PR TITLE
$ref support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ fast-json-stringify obj x 5,085,148 ops/sec ±1.56% (89 runs sampled)
  - <a href="#missingFields">`Missing fields`</a>
  - <a href="#patternProperties">`Pattern Properties`</a>
  - <a href="#additionalProperties">`Additional Properties`</a>
+ - <a href="#ref">`Reuse - $ref`</a>
 - <a href="#acknowledgements">`Acknowledgements`</a>
 - <a href="#license">`License`</a>
 
@@ -212,6 +213,85 @@ const obj = {
 }
 
 console.log(stringify(obj)) // '{"matchfoo":"42","otherfoo":"str","matchnum":3,"nomatchstr":"valar morghulis",nomatchint:"313","nickname":"nick"}'
+```
+
+<a name="ref"></a>
+#### Reuse - $ref
+If you want to reuse a definition of a value, you can use the property `$ref`.  
+The value of `$ref` must be a string in [JSON Pointer](https://tools.ietf.org/html/rfc6901) format.  
+Example:
+```javascript
+const schema = {
+  title: 'Example Schema',
+  definitions: {
+    num: {
+      type: 'object',
+      properties: {
+        int: {
+          type: 'integer'
+        }
+      }
+    },
+    str: {
+      type: 'string'
+    }
+  },
+  type: 'object',
+  properties: {
+    nickname: {
+      $ref: '#/definitions/str'
+    }
+  },
+  patternProperties: {
+    'num': {
+      $ref: '#/definitions/num'
+    }
+  },
+  additionalProperties: {
+    $ref: '#/definitions/def'
+  }
+}
+
+const stringify = fastJson(schema)
+```
+If you need to use an external definition, you can pass it as an option to `fast-json-stringify`.  
+Example:
+```javascript
+const schema = {
+  title: 'Example Schema',
+  type: 'object',
+  properties: {
+    nickname: {
+      $ref: 'strings#/definitions/str'
+    }
+  },
+  patternProperties: {
+    'num': {
+      $ref: 'numbers#/definitions/num'
+    }
+  },
+  additionalProperties: {
+    $ref: 'strings#/definitions/def'
+  }
+}
+
+const externalSchema = {
+  numbers: {
+    definitions: {
+      num: {
+        type: 'object',
+        properties: {
+          int: {
+            type: 'integer'
+          }
+        }
+      }
+    }
+  },
+  strings: require('./string-def.json')
+}
+
+const stringify = fastJson(schema, { schema: externalSchema })
 ```
 
 <a name="acknowledgements"></a>

--- a/test/ref.json
+++ b/test/ref.json
@@ -1,0 +1,12 @@
+{
+  "definitions": {
+    "def": {
+      "type": "object",
+      "properties": {
+        "str": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -1,0 +1,221 @@
+'use strict'
+
+const test = require('tap').test
+const build = require('..')
+
+test('ref internal - properties', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with $ref',
+    definitions: {
+      def: {
+        type: 'object',
+        properties: {
+          str: {
+            type: 'string'
+          }
+        }
+      }
+    },
+    type: 'object',
+    properties: {
+      obj: {
+        $ref: '#/definitions/def'
+      }
+    }
+  }
+
+  const object = {
+    obj: {
+      str: 'test'
+    }
+  }
+
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal('{"obj":{"str":"test"}}', output)
+})
+
+test('ref external - properties', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with $ref',
+    definitions: {
+      def: {
+        type: 'object',
+        properties: {
+          str: {
+            type: 'string'
+          }
+        }
+      }
+    },
+    type: 'object',
+    properties: {
+      obj: {
+        $ref: __dirname + '/ref.json#/definitions/def' // eslint-disable-line
+      }
+    }
+  }
+
+  const object = {
+    obj: {
+      str: 'test'
+    }
+  }
+
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal('{"obj":{"str":"test"}}', output)
+})
+
+test('ref internal - patternProperties', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with $ref',
+    definitions: {
+      def: {
+        type: 'object',
+        properties: {
+          str: {
+            type: 'string'
+          }
+        }
+      }
+    },
+    type: 'object',
+    properties: {},
+    patternProperties: {
+      obj: {
+        $ref: '#/definitions/def'
+      }
+    }
+  }
+
+  const object = {
+    obj: {
+      str: 'test'
+    }
+  }
+
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal('{"obj":{"str":"test"}}', output)
+})
+
+test('ref internal - additionalProperties', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with $ref',
+    definitions: {
+      def: {
+        type: 'object',
+        properties: {
+          str: {
+            type: 'string'
+          }
+        }
+      }
+    },
+    type: 'object',
+    properties: {},
+    additionalProperties: {
+      $ref: '#/definitions/def'
+    }
+  }
+
+  const object = {
+    obj: {
+      str: 'test'
+    }
+  }
+
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal('{"obj":{"str":"test"}}', output)
+})
+
+test('ref internal - pattern-additional Properties', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with $ref',
+    definitions: {
+      def: {
+        type: 'object',
+        properties: {
+          str: {
+            type: 'string'
+          }
+        }
+      }
+    },
+    type: 'object',
+    properties: {},
+    patternProperties: {
+      reg: {
+        $ref: '#/definitions/def'
+      }
+    },
+    additionalProperties: {
+      $ref: '#/definitions/def'
+    }
+  }
+
+  const object = {
+    reg: {
+      str: 'test'
+    },
+    obj: {
+      str: 'test'
+    }
+  }
+
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal('{"reg":{"str":"test"},"obj":{"str":"test"}}', output)
+})

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -48,22 +48,31 @@ test('ref internal - properties', (t) => {
 test('ref external - properties', (t) => {
   t.plan(2)
 
-  const schema = {
-    title: 'object with $ref',
-    definitions: {
-      def: {
-        type: 'object',
-        properties: {
-          str: {
-            type: 'string'
+  const externalSchema = {
+    first: require('./ref.json'),
+    second: {
+      definitions: {
+        num: {
+          type: 'object',
+          properties: {
+            int: {
+              type: 'integer'
+            }
           }
         }
       }
-    },
+    }
+  }
+
+  const schema = {
+    title: 'object with $ref',
     type: 'object',
     properties: {
       obj: {
-        $ref: __dirname + '/ref.json#/definitions/def' // eslint-disable-line
+        $ref: 'first#/definitions/def'
+      },
+      num: {
+        $ref: 'second#/definitions/num'
       }
     }
   }
@@ -71,10 +80,13 @@ test('ref external - properties', (t) => {
   const object = {
     obj: {
       str: 'test'
+    },
+    num: {
+      int: 42
     }
   }
 
-  const stringify = build(schema)
+  const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
   try {
@@ -84,7 +96,7 @@ test('ref external - properties', (t) => {
     t.fail()
   }
 
-  t.equal('{"obj":{"str":"test"}}', output)
+  t.equal('{"obj":{"str":"test"},"num":{"int":42}}', output)
 })
 
 test('ref internal - patternProperties', (t) => {
@@ -218,4 +230,59 @@ test('ref internal - pattern-additional Properties', (t) => {
   }
 
   t.equal('{"reg":{"str":"test"},"obj":{"str":"test"}}', output)
+})
+
+test('ref external - pattern-additional Properties', (t) => {
+  t.plan(2)
+
+  const externalSchema = {
+    first: require('./ref.json'),
+    second: {
+      definitions: {
+        num: {
+          type: 'object',
+          properties: {
+            int: {
+              type: 'integer'
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const schema = {
+    title: 'object with $ref',
+    type: 'object',
+    properties: {},
+    patternProperties: {
+      reg: {
+        $ref: 'first#/definitions/def'
+      }
+    },
+    additionalProperties: {
+      $ref: 'second#/definitions/num'
+    }
+  }
+
+  const object = {
+    reg: {
+      str: 'test'
+    },
+    obj: {
+      int: 42
+    }
+  }
+
+  const stringify = build(schema, { schema: externalSchema })
+  const output = stringify(object)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal('{"reg":{"str":"test"},"obj":{"int":42}}', output)
 })


### PR DESCRIPTION
As titled.
This implementation supports both *internal* and *external* definitions.

**Caveats:**
If the user is using an external json file for his definitions it must use `__dirname` to get the correct path.
See the following example (the same of the test).
```javascript
const schema = {
  title: 'object with $ref',
  type: 'object',
  properties: {
    obj: {
      $ref: __dirname + '/ref.json#/definitions/def'
    }
  }
}
```
If everything is ok to you I can update the docs.